### PR TITLE
Fix small typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to start, run:
 to stop, `CTRL+C`
 
 make light or heavy rain by adding a parameter between 1-10:
-`rainfall i=10`
+`rainfall -i=10`
 
 monochrome option:
 `rainfall -m`


### PR DESCRIPTION
The argument to change the intensity is `-i=X` but the Readme only states `i=X`. Small thing, but took me a minute to figure out why it wasn't working. 